### PR TITLE
Used 'lodash' package to prevent 'lodash.template' vulnerability (Severity: high).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,5 @@ dist
 .yarn/install-state.gz
 .pnp.*
 
+# Local files
+.idea

--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@ const pluginName = 'gulp-to-jst';
 const Vinyl = require('vinyl');
 const PluginError = require('plugin-error');
 const through = require('through');
-const assign = require('lodash.assign');
-const template = require('lodash.template');
+const assign = require('lodash/assign');
+const template = require('lodash/template');
 
 function pluginError(message) {
   return new PluginError(pluginName, message);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ilukanets/gulp-to-jst",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "lodash.assign": "^4.2.0",
-    "lodash.template": "^4.5.0",
+    "lodash": "^4.17.21",
     "plugin-error": "^1.0.1",
     "through": "^2.3.8",
     "vinyl": "^2.2.1"


### PR DESCRIPTION
`npm audit` revealed the following issue:

```zsh
lodash.template  *
Severity: high
Command Injection in lodash - https://github.com/advisories/GHSA-35jh-r3h4-6jhm
No fix available
node_modules/lodash.template
```

I've reviewed the details of the [Command Injection in lodash](https://github.com/advisories/GHSA-35jh-r3h4-6jhm) vulnerability and found the [reported issue](https://github.com/lodash/lodash/issues/5896) in the `lodash` repository, along with a [related comment](https://github.com/lodash/lodash/issues/5896#issuecomment-2206176135) there. This comment contains a reference to [working solution](https://github.com/lodash/lodash/issues/5738#issuecomment-1737782579), which I've implemented in this PR.
